### PR TITLE
feat: インストールスクリプトに実行権限付与メッセージを追加

### DIFF
--- a/.claude/scripts/install-to-existing.sh
+++ b/.claude/scripts/install-to-existing.sh
@@ -188,9 +188,13 @@ if [ "$CLAUDE_DIR_EXISTS" = true ]; then
   mkdir -p "$TARGET_DIR/.claude/scripts"
   cp -r "$TEMPLATE_ROOT/.claude/commands/aad" "$TARGET_DIR/.claude/commands/"
   cp "$TEMPLATE_ROOT/.claude/scripts/"* "$TARGET_DIR/.claude/scripts/" 2>/dev/null || true
+  chmod +x "$TARGET_DIR/.claude/scripts/"*.sh 2>/dev/null || true
+  echo "  ✅ スクリプトに実行権限を付与しました"
   echo "  ✅ .claude/ にaadコマンドとスクリプトをマージしました"
 else
   cp -r "$TEMPLATE_ROOT/.claude" "$TARGET_DIR/"
+  chmod +x "$TARGET_DIR/.claude/scripts/"*.sh 2>/dev/null || true
+  echo "  ✅ スクリプトに実行権限を付与しました"
   echo "  ✅ .claude/ を作成しました"
 fi
 

--- a/.claude/scripts/install-to-new.sh
+++ b/.claude/scripts/install-to-new.sh
@@ -111,6 +111,10 @@ mkdir -p "$TARGET_DIR/.aad/worktrees"
 touch "$TARGET_DIR/.aad/worktrees/.gitkeep"
 echo "  ✅ .aad/worktrees/ を作成しました"
 
+# スクリプトに実行権限を付与
+chmod +x "$TARGET_DIR/.claude/scripts/"*.sh 2>/dev/null || true
+echo "  ✅ スクリプトに実行権限を付与しました"
+
 # .aad/retrospectivesのファイルを削除（テンプレートは別ディレクトリ）
 find "$TARGET_DIR/.aad/retrospectives" -name "*.md" -delete 2>/dev/null || true
 


### PR DESCRIPTION
## 概要
インストールスクリプトに実行権限付与の処理とメッセージを追加しました。

## 変更内容
- `install-to-existing.sh`: スクリプトコピー後に自動的に実行権限を付与
- `install-to-new.sh`: スクリプトコピー後に自動的に実行権限を付与
- 実行権限付与完了メッセージを追加

## 改善点
インストール後にユーザーが手動で `chmod +x` を実行する必要がなくなりました。

## テスト
- [ ] install-to-existing.sh の実行確認
- [ ] install-to-new.sh の実行確認
- [ ] コピーされたスクリプトに実行権限が付与されていることを確認