### PR TITLE
feat(SPEC-004-T04): モニターループ実装

### DIFF
--- a/crates/application/src/orchestration/mod.rs
+++ b/crates/application/src/orchestration/mod.rs
@@ -8,8 +8,10 @@
 
 pub mod config;
 pub mod dependency_graph;
+pub mod monitor;
 pub mod orchestrator;
 
 pub use config::OrchestratorConfig;
 pub use dependency_graph::DependencyGraph;
+pub use monitor::{MonitorEvent, MonitorProgress, SessionStatus};
 pub use orchestrator::Orchestrator;

--- a/crates/application/src/orchestration/monitor.rs
+++ b/crates/application/src/orchestration/monitor.rs
@@ -1,0 +1,278 @@
+//! Session monitoring and progress tracking for the orchestrator.
+//!
+//! This module provides types and utilities for monitoring session status,
+//! tracking progress, and logging orchestration events.
+
+use super::orchestrator::SessionId;
+
+/// Status of a session in the orchestrator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionStatus {
+    /// Session is waiting to be started.
+    Pending,
+    /// Session is currently running.
+    Running,
+    /// Session completed successfully.
+    Completed,
+    /// Session timed out.
+    TimedOut,
+    /// Session failed with an error.
+    Failed,
+}
+
+impl SessionStatus {
+    /// Returns true if this status is a terminal state (session is done).
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            SessionStatus::Completed | SessionStatus::TimedOut | SessionStatus::Failed
+        )
+    }
+}
+
+/// Events that occur during session monitoring.
+#[derive(Debug, Clone)]
+pub enum MonitorEvent {
+    /// A session was started.
+    SessionStarted {
+        /// ID of the started session.
+        session_id: SessionId,
+        /// Spec ID associated with the session.
+        spec_id: String,
+    },
+    /// A session completed successfully.
+    SessionCompleted {
+        /// ID of the completed session.
+        session_id: SessionId,
+        /// Duration in seconds.
+        duration_secs: u64,
+    },
+    /// A session timed out.
+    SessionTimedOut {
+        /// ID of the timed-out session.
+        session_id: SessionId,
+        /// Timeout threshold in seconds.
+        timeout_secs: u64,
+    },
+    /// A session failed.
+    SessionFailed {
+        /// ID of the failed session.
+        session_id: SessionId,
+        /// Failure reason.
+        reason: String,
+    },
+    /// Progress update for all sessions.
+    ProgressUpdate {
+        /// Number of completed sessions.
+        completed: usize,
+        /// Total number of sessions.
+        total: usize,
+        /// Completion percentage (0-100).
+        percent: u8,
+    },
+}
+
+/// Progress statistics for all sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonitorProgress {
+    /// Total number of sessions.
+    pub total_sessions: usize,
+    /// Number of completed sessions.
+    pub completed_sessions: usize,
+    /// Number of failed sessions.
+    pub failed_sessions: usize,
+    /// Number of timed-out sessions.
+    pub timed_out_sessions: usize,
+    /// Number of currently running sessions.
+    pub running_sessions: usize,
+    /// Number of pending sessions.
+    pub pending_sessions: usize,
+}
+
+impl MonitorProgress {
+    /// Creates a new progress tracker with all counters set to zero.
+    pub fn new() -> Self {
+        Self {
+            total_sessions: 0,
+            completed_sessions: 0,
+            failed_sessions: 0,
+            timed_out_sessions: 0,
+            running_sessions: 0,
+            pending_sessions: 0,
+        }
+    }
+
+    /// Calculates the overall progress percentage (0-100).
+    ///
+    /// Progress is based on terminal states (completed + failed + timed-out).
+    pub fn progress_percent(&self) -> u8 {
+        if self.total_sessions == 0 {
+            return 100;
+        }
+
+        let terminal_count =
+            self.completed_sessions + self.failed_sessions + self.timed_out_sessions;
+        ((terminal_count * 100) / self.total_sessions) as u8
+    }
+
+    /// Returns true if all sessions are in a terminal state.
+    pub fn all_terminal(&self) -> bool {
+        self.total_sessions > 0
+            && (self.completed_sessions + self.failed_sessions + self.timed_out_sessions
+                == self.total_sessions)
+    }
+}
+
+impl Default for MonitorProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Logging utilities for orchestration events.
+pub mod log {
+    use super::MonitorEvent;
+
+    /// Logs an informational message.
+    pub fn info(message: &str) {
+        println!("[INFO] {}", message);
+    }
+
+    /// Logs a warning message.
+    pub fn warn(message: &str) {
+        eprintln!("[WARN] {}", message);
+    }
+
+    /// Logs an error message.
+    pub fn error(message: &str) {
+        eprintln!("[ERROR] {}", message);
+    }
+
+    /// Logs a progress message.
+    pub fn progress(message: &str) {
+        println!("[PROGRESS] {}", message);
+    }
+
+    /// Logs a monitor event with appropriate formatting.
+    pub fn event(event: &MonitorEvent) {
+        match event {
+            MonitorEvent::SessionStarted {
+                session_id,
+                spec_id,
+            } => {
+                info(&format!(
+                    "Session started: {} (spec: {})",
+                    session_id, spec_id
+                ));
+            }
+            MonitorEvent::SessionCompleted {
+                session_id,
+                duration_secs,
+            } => {
+                info(&format!(
+                    "Session completed: {} (duration: {}s)",
+                    session_id, duration_secs
+                ));
+            }
+            MonitorEvent::SessionTimedOut {
+                session_id,
+                timeout_secs,
+            } => {
+                warn(&format!(
+                    "Session timed out: {} (timeout: {}s)",
+                    session_id, timeout_secs
+                ));
+            }
+            MonitorEvent::SessionFailed { session_id, reason } => {
+                error(&format!("Session failed: {} (reason: {})", session_id, reason));
+            }
+            MonitorEvent::ProgressUpdate {
+                completed,
+                total,
+                percent,
+            } => {
+                progress(&format!(
+                    "Overall progress: {}/{} ({}%)",
+                    completed, total, percent
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_status_is_terminal() {
+        assert!(!SessionStatus::Pending.is_terminal());
+        assert!(!SessionStatus::Running.is_terminal());
+        assert!(SessionStatus::Completed.is_terminal());
+        assert!(SessionStatus::TimedOut.is_terminal());
+        assert!(SessionStatus::Failed.is_terminal());
+    }
+
+    #[test]
+    fn test_monitor_progress_new() {
+        let progress = MonitorProgress::new();
+        assert_eq!(progress.total_sessions, 0);
+        assert_eq!(progress.completed_sessions, 0);
+        assert_eq!(progress.failed_sessions, 0);
+        assert_eq!(progress.timed_out_sessions, 0);
+        assert_eq!(progress.running_sessions, 0);
+        assert_eq!(progress.pending_sessions, 0);
+    }
+
+    #[test]
+    fn test_monitor_progress_percent_empty() {
+        let progress = MonitorProgress::new();
+        assert_eq!(progress.progress_percent(), 100);
+    }
+
+    #[test]
+    fn test_monitor_progress_percent() {
+        let progress = MonitorProgress {
+            total_sessions: 10,
+            completed_sessions: 5,
+            failed_sessions: 2,
+            timed_out_sessions: 1,
+            running_sessions: 2,
+            pending_sessions: 0,
+        };
+        // (5 + 2 + 1) / 10 * 100 = 80%
+        assert_eq!(progress.progress_percent(), 80);
+    }
+
+    #[test]
+    fn test_monitor_progress_all_terminal() {
+        let progress = MonitorProgress {
+            total_sessions: 5,
+            completed_sessions: 3,
+            failed_sessions: 1,
+            timed_out_sessions: 1,
+            running_sessions: 0,
+            pending_sessions: 0,
+        };
+        assert!(progress.all_terminal());
+    }
+
+    #[test]
+    fn test_monitor_progress_not_all_terminal() {
+        let progress = MonitorProgress {
+            total_sessions: 5,
+            completed_sessions: 3,
+            failed_sessions: 1,
+            timed_out_sessions: 0,
+            running_sessions: 1,
+            pending_sessions: 0,
+        };
+        assert!(!progress.all_terminal());
+    }
+
+    #[test]
+    fn test_monitor_progress_empty_not_terminal() {
+        let progress = MonitorProgress::new();
+        assert!(!progress.all_terminal());
+    }
+}

--- a/crates/application/src/orchestration/orchestrator.rs
+++ b/crates/application/src/orchestration/orchestrator.rs
@@ -1,11 +1,13 @@
 //! Core orchestrator for managing multiple sessions.
 
+use super::monitor::{MonitorEvent, MonitorProgress, SessionStatus};
 use super::{DependencyGraph, OrchestratorConfig};
 use crate::error::{ApplicationError, Result};
 use domain::entities::Session;
 use domain::value_objects::{Phase, SpecId};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 /// SessionId type alias.
@@ -33,6 +35,12 @@ pub struct Orchestrator {
     /// Active sessions, keyed by session ID.
     sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
 
+    /// Session statuses for monitoring.
+    session_statuses: Arc<RwLock<HashMap<SessionId, SessionStatus>>>,
+
+    /// Session start times for timeout tracking.
+    session_start_times: Arc<RwLock<HashMap<SessionId, Instant>>>,
+
     /// Dependency graph for managing spec execution order.
     dependency_graph: Arc<RwLock<DependencyGraph>>,
 }
@@ -52,6 +60,8 @@ impl Orchestrator {
         Self {
             config,
             sessions: Arc::new(RwLock::new(HashMap::new())),
+            session_statuses: Arc::new(RwLock::new(HashMap::new())),
+            session_start_times: Arc::new(RwLock::new(HashMap::new())),
             dependency_graph: Arc::new(RwLock::new(DependencyGraph::new())),
         }
     }
@@ -88,6 +98,12 @@ impl Orchestrator {
         }
 
         sessions.insert(session_id.clone(), session);
+        drop(sessions);
+
+        // Register session status as Pending
+        let mut statuses = self.session_statuses.write().await;
+        statuses.insert(session_id.clone(), SessionStatus::Pending);
+
         Ok(session_id)
     }
 
@@ -102,7 +118,18 @@ impl Orchestrator {
     /// The removed session if it existed, or None if it did not.
     pub async fn remove_session(&self, session_id: &SessionId) -> Option<Session> {
         let mut sessions = self.sessions.write().await;
-        sessions.remove(session_id)
+        let removed_session = sessions.remove(session_id);
+        drop(sessions);
+
+        // Also remove from statuses and start times
+        let mut statuses = self.session_statuses.write().await;
+        statuses.remove(session_id);
+        drop(statuses);
+
+        let mut start_times = self.session_start_times.write().await;
+        start_times.remove(session_id);
+
+        removed_session
     }
 
     /// Gets a session by its ID.
@@ -239,6 +266,15 @@ impl Orchestrator {
                 session_id
             )));
         }
+        drop(sessions);
+
+        // Mark session as Running and record start time
+        let mut statuses = self.session_statuses.write().await;
+        statuses.insert(session_id.clone(), SessionStatus::Running);
+        drop(statuses);
+
+        let mut start_times = self.session_start_times.write().await;
+        start_times.insert(session_id.clone(), Instant::now());
 
         // TODO: Launch Child Session process
         // For now, we just validate that the session exists
@@ -313,6 +349,231 @@ impl Orchestrator {
     pub async fn get_parallel_execution_groups(&self) -> Result<Vec<Vec<String>>> {
         let graph = self.dependency_graph.read().await;
         graph.get_parallel_groups()
+    }
+
+    /// Marks a session as completed.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_id` - The ID of the session to mark as completed
+    pub async fn mark_session_completed(&self, session_id: &SessionId) {
+        let mut statuses = self.session_statuses.write().await;
+        statuses.insert(session_id.clone(), SessionStatus::Completed);
+    }
+
+    /// Marks a session as failed.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_id` - The ID of the session to mark as failed
+    pub async fn mark_session_failed(&self, session_id: &SessionId) {
+        let mut statuses = self.session_statuses.write().await;
+        statuses.insert(session_id.clone(), SessionStatus::Failed);
+    }
+
+    /// Gets the status of a session.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_id` - The ID of the session
+    ///
+    /// # Returns
+    ///
+    /// The session status, or None if the session doesn't exist.
+    pub async fn get_session_status(&self, session_id: &SessionId) -> Option<SessionStatus> {
+        let statuses = self.session_statuses.read().await;
+        statuses.get(session_id).copied()
+    }
+
+    /// Determines the current status of a session based on its runtime.
+    ///
+    /// Checks if the session has timed out based on the configured timeout.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_id` - The ID of the session
+    ///
+    /// # Returns
+    ///
+    /// The determined session status.
+    async fn determine_session_status(&self, session_id: &SessionId) -> SessionStatus {
+        let statuses = self.session_statuses.read().await;
+        let current_status = statuses.get(session_id).copied();
+        drop(statuses);
+
+        // If already in a terminal state, return it
+        if let Some(status) = current_status {
+            if status.is_terminal() {
+                return status;
+            }
+        }
+
+        // Check for timeout
+        let start_times = self.session_start_times.read().await;
+        if let Some(start_time) = start_times.get(session_id) {
+            let elapsed = start_time.elapsed();
+            let timeout_duration = Duration::from_secs(self.config.session_timeout_secs);
+
+            if elapsed >= timeout_duration {
+                drop(start_times);
+                // Mark as timed out
+                let mut statuses = self.session_statuses.write().await;
+                statuses.insert(session_id.clone(), SessionStatus::TimedOut);
+                return SessionStatus::TimedOut;
+            }
+        }
+
+        current_status.unwrap_or(SessionStatus::Pending)
+    }
+
+    /// Calculates overall progress for all sessions.
+    ///
+    /// # Returns
+    ///
+    /// A `MonitorProgress` struct containing progress statistics.
+    pub async fn calculate_progress(&self) -> MonitorProgress {
+        let statuses = self.session_statuses.read().await;
+
+        let mut progress = MonitorProgress::new();
+        progress.total_sessions = statuses.len();
+
+        for status in statuses.values() {
+            match status {
+                SessionStatus::Pending => progress.pending_sessions += 1,
+                SessionStatus::Running => progress.running_sessions += 1,
+                SessionStatus::Completed => progress.completed_sessions += 1,
+                SessionStatus::TimedOut => progress.timed_out_sessions += 1,
+                SessionStatus::Failed => progress.failed_sessions += 1,
+            }
+        }
+
+        progress
+    }
+
+    /// Handles a monitor event by logging it.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The monitor event to handle
+    fn handle_monitor_event(&self, event: &MonitorEvent) {
+        super::monitor::log::event(event);
+    }
+
+    /// Checks all sessions and returns a list of events for status changes.
+    ///
+    /// # Returns
+    ///
+    /// A vector of monitor events for sessions that changed status.
+    async fn check_all_sessions(&self) -> Vec<MonitorEvent> {
+        let mut events = Vec::new();
+
+        let sessions = self.sessions.read().await;
+        let session_ids: Vec<SessionId> = sessions.keys().cloned().collect();
+        drop(sessions);
+
+        for session_id in session_ids {
+            let old_status = self.get_session_status(&session_id).await;
+            let new_status = self.determine_session_status(&session_id).await;
+
+            // If status changed to a terminal state, generate an event
+            if old_status != Some(new_status) && new_status.is_terminal() {
+                match new_status {
+                    SessionStatus::Completed => {
+                        let start_times = self.session_start_times.read().await;
+                        let duration_secs = start_times
+                            .get(&session_id)
+                            .map(|start| start.elapsed().as_secs())
+                            .unwrap_or(0);
+                        events.push(MonitorEvent::SessionCompleted {
+                            session_id,
+                            duration_secs,
+                        });
+                    }
+                    SessionStatus::TimedOut => {
+                        events.push(MonitorEvent::SessionTimedOut {
+                            session_id,
+                            timeout_secs: self.config.session_timeout_secs,
+                        });
+                    }
+                    SessionStatus::Failed => {
+                        events.push(MonitorEvent::SessionFailed {
+                            session_id,
+                            reason: "Unknown error".to_string(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        events
+    }
+
+    /// Main monitoring loop that tracks session progress.
+    ///
+    /// This loop runs continuously, checking session status every
+    /// `monitor_interval_secs` seconds. It logs events and progress updates.
+    ///
+    /// The loop exits when all sessions reach a terminal state.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use application::orchestration::{Orchestrator, OrchestratorConfig};
+    /// use domain::value_objects::{SpecId, Phase};
+    ///
+    /// # async {
+    /// let config = OrchestratorConfig::default();
+    /// let orchestrator = Orchestrator::new(config);
+    ///
+    /// // Register and start sessions
+    /// let spec = SpecId::new();
+    /// orchestrator.register_spec(&spec, Phase::Tdd).await.unwrap();
+    /// orchestrator.start_all_sessions().await.unwrap();
+    ///
+    /// // Start monitoring loop (blocks until all sessions complete)
+    /// orchestrator.monitor_loop().await;
+    /// # };
+    /// ```
+    pub async fn monitor_loop(&self) {
+        use super::monitor::log;
+
+        log::info("Starting monitor loop");
+
+        let interval_duration = Duration::from_secs(self.config.monitor_interval_secs);
+        let mut interval = tokio::time::interval(interval_duration);
+
+        loop {
+            interval.tick().await;
+
+            // Check all sessions for status changes
+            let events = self.check_all_sessions().await;
+
+            // Handle each event
+            for event in events {
+                self.handle_monitor_event(&event);
+            }
+
+            // Calculate and log progress
+            let progress = self.calculate_progress().await;
+
+            if progress.total_sessions > 0 {
+                let progress_event = MonitorEvent::ProgressUpdate {
+                    completed: progress.completed_sessions
+                        + progress.failed_sessions
+                        + progress.timed_out_sessions,
+                    total: progress.total_sessions,
+                    percent: progress.progress_percent(),
+                };
+                self.handle_monitor_event(&progress_event);
+            }
+
+            // Exit loop if all sessions are in terminal state
+            if progress.all_terminal() {
+                log::info("All sessions completed, exiting monitor loop");
+                break;
+            }
+        }
     }
 }
 
@@ -647,5 +908,159 @@ mod tests {
         assert_eq!(filtered_groups[1].len(), 2);
         assert!(filtered_groups[1].contains(&spec2.to_string()));
         assert!(filtered_groups[1].contains(&spec3.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_session_status_pending_on_add() {
+        let config = OrchestratorConfig::default();
+        let orchestrator = Orchestrator::new(config);
+
+        let session = Session::new(SpecId::new(), Phase::Tdd);
+        let session_id = orchestrator.add_session(session).await.unwrap();
+
+        let status = orchestrator.get_session_status(&session_id).await;
+        assert_eq!(status, Some(SessionStatus::Pending));
+    }
+
+    #[tokio::test]
+    async fn test_session_status_running_on_start() {
+        let config = OrchestratorConfig::default();
+        let orchestrator = Orchestrator::new(config);
+
+        let spec_id = SpecId::new();
+        let session_id = orchestrator
+            .register_spec(&spec_id, Phase::Tdd)
+            .await
+            .unwrap();
+
+        orchestrator.start_session(&session_id).await.unwrap();
+
+        let status = orchestrator.get_session_status(&session_id).await;
+        assert_eq!(status, Some(SessionStatus::Running));
+    }
+
+    #[tokio::test]
+    async fn test_mark_session_completed() {
+        let config = OrchestratorConfig::default();
+        let orchestrator = Orchestrator::new(config);
+
+        let session = Session::new(SpecId::new(), Phase::Tdd);
+        let session_id = orchestrator.add_session(session).await.unwrap();
+
+        orchestrator.mark_session_completed(&session_id).await;
+
+        let status = orchestrator.get_session_status(&session_id).await;
+        assert_eq!(status, Some(SessionStatus::Completed));
+    }
+
+    #[tokio::test]
+    async fn test_mark_session_failed() {
+        let config = OrchestratorConfig::default();
+        let orchestrator = Orchestrator::new(config);
+
+        let session = Session::new(SpecId::new(), Phase::Tdd);
+        let session_id = orchestrator.add_session(session).await.unwrap();
+
+        orchestrator.mark_session_failed(&session_id).await;
+
+        let status = orchestrator.get_session_status(&session_id).await;
+        assert_eq!(status, Some(SessionStatus::Failed));
+    }
+
+    #[tokio::test]
+    async fn test_calculate_progress() {
+        let config = OrchestratorConfig::default();
+        let orchestrator = Orchestrator::new(config);
+
+        // Add sessions
+        let session1 = Session::new(SpecId::new(), Phase::Tdd);
+        let session2 = Session::new(SpecId::new(), Phase::Tdd);
+        let session3 = Session::new(SpecId::new(), Phase::Tdd);
+
+        let id1 = orchestrator.add_session(session1).await.unwrap();
+        let id2 = orchestrator.add_session(session2).await.unwrap();
+        let _id3 = orchestrator.add_session(session3).await.unwrap();
+
+        // Mark different statuses
+        orchestrator.mark_session_completed(&id1).await;
+        orchestrator.mark_session_failed(&id2).await;
+        // id3 remains Pending
+
+        let progress = orchestrator.calculate_progress().await;
+        assert_eq!(progress.total_sessions, 3);
+        assert_eq!(progress.completed_sessions, 1);
+        assert_eq!(progress.failed_sessions, 1);
+        assert_eq!(progress.pending_sessions, 1);
+        assert_eq!(progress.progress_percent(), 66); // (1 + 1) / 3 * 100 = 66
+    }
+
+    #[tokio::test]
+    async fn test_session_timeout_detection() {
+        let config = OrchestratorConfig {
+            max_parallel_sessions: 4,
+            session_timeout_secs: 1, // 1 second timeout for testing
+            monitor_interval_secs: 1,
+        };
+        let orchestrator = Orchestrator::new(config);
+
+        let spec_id = SpecId::new();
+        let session_id = orchestrator
+            .register_spec(&spec_id, Phase::Tdd)
+            .await
+            .unwrap();
+
+        orchestrator.start_session(&session_id).await.unwrap();
+
+        // Wait for timeout
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let status = orchestrator.determine_session_status(&session_id).await;
+        assert_eq!(status, SessionStatus::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn test_monitor_loop_exits_when_all_terminal() {
+        let config = OrchestratorConfig {
+            max_parallel_sessions: 4,
+            session_timeout_secs: 3600,
+            monitor_interval_secs: 1,
+        };
+        let orchestrator = Orchestrator::new(config);
+
+        // Add a session
+        let session = Session::new(SpecId::new(), Phase::Tdd);
+        let session_id = orchestrator.add_session(session).await.unwrap();
+
+        // Mark as completed immediately
+        orchestrator.mark_session_completed(&session_id).await;
+
+        // Monitor loop should exit immediately
+        let start = Instant::now();
+        orchestrator.monitor_loop().await;
+        let elapsed = start.elapsed();
+
+        // Should exit quickly (within 2 seconds)
+        assert!(elapsed < Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn test_remove_session_clears_status() {
+        let config = OrchestratorConfig::default();
+        let orchestrator = Orchestrator::new(config);
+
+        let session = Session::new(SpecId::new(), Phase::Tdd);
+        let session_id = orchestrator.add_session(session).await.unwrap();
+
+        // Verify status exists
+        assert_eq!(
+            orchestrator.get_session_status(&session_id).await,
+            Some(SessionStatus::Pending)
+        );
+
+        // Remove session
+        orchestrator.remove_session(&session_id).await;
+
+        // Status should be gone
+        assert_eq!(orchestrator.get_session_status(&session_id).await, None);
     }
 }


### PR DESCRIPTION
## 概要

SPEC-004-T04: Orchestratorにモニターループ機能を実装しました。

## 主な変更

### 新規ファイル
- **monitor.rs**: セッション監視・進捗追跡機能
  - `SessionStatus` enum: セッション状態管理
  - `MonitorEvent` enum: モニターイベント定義
  - `MonitorProgress` struct: 進捗統計
  - `log` module: 構造化ログ出力

### 変更ファイル
- **mod.rs**: monitorモジュール追加
- **orchestrator.rs**: モニター機能統合
  - `session_statuses`: セッション状態マップ
  - `session_start_times`: 開始時刻記録
  - `monitor_loop()`: メイン監視ループ
  - `check_all_sessions()`: 状態変化検出
  - `calculate_progress()`: 進捗計算
  - `determine_session_status()`: タイムアウト判定

## 受入基準達成状況

- [x] AC-3.1: `monitor_loop()`が非同期で実装されている
- [x] AC-3.2: 1秒ごとに全セッションの状態をチェック
- [x] AC-3.3: 完了・失敗・タイムアウトを検出
- [x] AC-3.4: セッションの進捗率が計算される
- [x] AC-3.5: ログが適切に記録される

## テスト

以下のテストケースを追加・確認しました:

- SessionStatus動作テスト
- MonitorProgress計算テスト
- セッション状態管理テスト
- タイムアウト検出テスト
- monitor_loop終了条件テスト

全59テストが成功しています。

## ビルド・品質チェック

```bash
cargo build -p application    # ✓ 成功
cargo test -p application      # ✓ 59テスト成功
cargo clippy -p application    # ✓ 警告なし
```

## 次のステップ

このPRがマージされると、SPEC-004の全タスクが完了します。
オーケストレーション機能の基盤が整い、実際のChild Session統合に進めます。