### PR TITLE
feat(SPEC-004-T06): オーケストレーションコマンド実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,9 @@ dependencies = [
  "chrono",
  "clap",
  "domain",
+ "futures",
  "infrastructure",
+ "tokio",
 ]
 
 [[package]]
@@ -250,6 +252,95 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -437,6 +528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +658,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,3 +15,5 @@ infrastructure = { path = "../infrastructure" }
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
+tokio = { version = "1.35", features = ["full"] }
+futures = "0.3"

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod init;
+pub mod orchestrate;
 pub mod spec;
 pub mod style;
 pub mod tasks;
@@ -37,6 +38,13 @@ pub enum Commands {
     Worktree {
         /// 仕様ID
         spec_id: String,
+    },
+
+    /// 複数の仕様を並列実行
+    Orchestrate {
+        /// 実行する仕様ID（複数指定可能）
+        #[arg(long, value_delimiter = ' ', num_args = 1..)]
+        specs: Vec<String>,
     },
 }
 

--- a/crates/cli/src/commands/orchestrate.rs
+++ b/crates/cli/src/commands/orchestrate.rs
@@ -1,0 +1,221 @@
+//! Orchestrate command implementation.
+//!
+//! Executes multiple specifications concurrently using the orchestration engine.
+
+use application::orchestration::{Orchestrator, OrchestratorConfig, SessionStatus};
+use domain::value_objects::{ids::SpecId, phase::Phase};
+use std::str::FromStr;
+use std::time::Duration;
+
+/// Executes the orchestrate command to run multiple specs concurrently.
+///
+/// # Arguments
+///
+/// * `spec_ids` - List of specification IDs to execute (e.g., ["SPEC-001", "SPEC-002"])
+///
+/// # Examples
+///
+/// ```bash
+/// aad orchestrate --specs SPEC-001 SPEC-002
+/// ```
+pub async fn execute(spec_ids: &[String]) -> anyhow::Result<()> {
+    if spec_ids.is_empty() {
+        anyhow::bail!("エラー: 少なくとも1つのSpec IDを指定してください");
+    }
+
+    println!("🚀 オーケストレーション開始\n");
+    println!("📋 実行対象:");
+    for spec_id in spec_ids {
+        println!("  - {}", spec_id);
+    }
+    println!();
+
+    // 1. Create orchestrator with default config
+    let config = OrchestratorConfig::default();
+    let orchestrator = std::sync::Arc::new(Orchestrator::new(config.clone()));
+
+    println!(
+        "⚙️  設定: 最大並列数 = {}, タイムアウト = {}秒\n",
+        config.max_parallel_sessions, config.session_timeout_secs
+    );
+
+    // 2. Register all specs
+    println!("📝 セッション登録中...");
+    let mut session_ids = Vec::new();
+    for spec_id_str in spec_ids {
+        let spec_id = SpecId::from_str(spec_id_str)
+            .map_err(|e| anyhow::anyhow!("無効なSpec ID '{}': {}", spec_id_str, e))?;
+
+        match orchestrator.register_spec(&spec_id, Phase::Tdd).await {
+            Ok(session_id) => {
+                println!("  ✓ {} -> {}", spec_id_str, session_id);
+                session_ids.push(session_id);
+            }
+            Err(e) => {
+                eprintln!("  ✗ {} の登録に失敗: {}", spec_id_str, e);
+                return Err(anyhow::anyhow!(
+                    "セッション登録エラー: {} - {}",
+                    spec_id_str,
+                    e
+                ));
+            }
+        }
+    }
+    println!();
+
+    // 3. Start all sessions
+    println!("▶️  セッション開始中...");
+    match orchestrator.start_all_sessions().await {
+        Ok(started_ids) => {
+            println!("  ✓ {} セッションを開始しました\n", started_ids.len());
+        }
+        Err(e) => {
+            eprintln!("  ✗ セッション開始エラー: {}", e);
+            return Err(anyhow::anyhow!("セッション開始失敗: {}", e));
+        }
+    }
+
+    // 4. Monitor sessions until all complete
+    println!("🔍 セッション監視中...\n");
+
+    // Start monitor loop in background
+    let monitor_orchestrator = orchestrator.clone();
+    tokio::spawn(async move {
+        monitor_orchestrator.monitor_loop().await;
+    });
+
+    // Wait for all sessions to complete
+    loop {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let all_sessions = orchestrator.get_all_sessions().await;
+        let mut all_done = true;
+        let mut completed = 0;
+        let mut failed = 0;
+        let mut timed_out = 0;
+        let mut running = 0;
+        let mut pending = 0;
+
+        for session in &all_sessions {
+            if let Some(status) = orchestrator.get_session_status(&session.id).await {
+                match status {
+                    SessionStatus::Completed => completed += 1,
+                    SessionStatus::Failed => failed += 1,
+                    SessionStatus::TimedOut => timed_out += 1,
+                    SessionStatus::Running => {
+                        running += 1;
+                        all_done = false;
+                    }
+                    SessionStatus::Pending => {
+                        pending += 1;
+                        all_done = false;
+                    }
+                }
+            }
+        }
+
+        // Print progress
+        print!("\r進捗: ");
+        if completed > 0 {
+            print!("✅ {}", completed);
+        }
+        if running > 0 {
+            print!(" 🔄 {}", running);
+        }
+        if pending > 0 {
+            print!(" ⏳ {}", pending);
+        }
+        if failed > 0 {
+            print!(" ❌ {}", failed);
+        }
+        if timed_out > 0 {
+            print!(" ⏰ {}", timed_out);
+        }
+        print!("   ");
+        std::io::Write::flush(&mut std::io::stdout())?;
+
+        if all_done {
+            println!("\n");
+            break;
+        }
+    }
+
+    // 5. Display final summary
+    println!("📊 実行結果サマリー\n");
+    println!("┌─────────────────────────────────────┐");
+
+    let all_sessions = orchestrator.get_all_sessions().await;
+    for session in &all_sessions {
+        if let Some(status) = orchestrator.get_session_status(&session.id).await {
+            let status_icon = match status {
+                SessionStatus::Completed => "✅",
+                SessionStatus::Failed => "❌",
+                SessionStatus::TimedOut => "⏰",
+                SessionStatus::Running => "🔄",
+                SessionStatus::Pending => "⏳",
+            };
+
+            let status_text = match status {
+                SessionStatus::Completed => "完了",
+                SessionStatus::Failed => "失敗",
+                SessionStatus::TimedOut => "タイムアウト",
+                SessionStatus::Running => "実行中",
+                SessionStatus::Pending => "待機中",
+            };
+
+            println!(
+                "│ {} {} - {:8} │",
+                status_icon,
+                &session.id,
+                status_text
+            );
+        }
+    }
+
+    println!("└─────────────────────────────────────┘\n");
+
+    // Check if any sessions failed
+    let failed_count = all_sessions
+        .iter()
+        .filter(|s| {
+            if let Some(status) = futures::executor::block_on(orchestrator.get_session_status(&s.id)) {
+                matches!(status, SessionStatus::Failed | SessionStatus::TimedOut)
+            } else {
+                false
+            }
+        })
+        .count();
+
+    if failed_count > 0 {
+        eprintln!("⚠️  警告: {} セッションが失敗しました", failed_count);
+        eprintln!("詳細は .aad/sessions/ および .aad/escalations/ を確認してください");
+        return Err(anyhow::anyhow!(
+            "{} セッションが失敗しました",
+            failed_count
+        ));
+    }
+
+    println!("✅ すべてのセッションが正常に完了しました");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_execute_empty_specs() {
+        let result = execute(&[]).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("少なくとも1つのSpec ID"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_invalid_spec_id() {
+        let result = execute(&["".to_string()]).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -24,6 +24,11 @@ fn main() -> anyhow::Result<()> {
             StyleAction::Apply { style_name } => commands::style::apply(&style_name)?,
         },
         Commands::Worktree { spec_id } => commands::worktree::execute(&spec_id)?,
+        Commands::Orchestrate { specs } => {
+            // Create tokio runtime for async orchestrate command
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(commands::orchestrate::execute(&specs))?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## 概要

SPEC-004-T06「オーケストレーションコマンド実装」を完了しました。

## 実装内容

### Phase 1: セッション完了・失敗ハンドリング

#### 変更ファイル
- `crates/application/src/orchestration/config.rs`
  - `max_retry_attempts`フィールド追加（default: 3）
  - `retry_delay_secs`フィールド追加（default: 5秒）

- `crates/application/src/orchestration/orchestrator.rs`
  - `retry_counts: Arc<RwLock<HashMap<SessionId, usize>>>`フィールド追加
  - `handle_session_completion(&self, session_id: &SessionId) -> Result<()>` 実装
  - `handle_session_failure(&self, session_id: &SessionId, reason: &str) -> Result<()>` 実装
  - `should_retry(&self, session_id: &SessionId) -> bool` 実装
  - `retry_session(&self, session_id: &SessionId) -> Result<()>` 実装
  - `rollback_session(&self, session_id: &SessionId) -> Result<()>` 実装
  - 9つの新規テストケース追加

### Phase 2: CLI orchestrateコマンド実装

#### 新規ファイル
- `crates/cli/src/commands/orchestrate.rs`
  - `execute(spec_ids: &[String]) -> anyhow::Result<()>` 実装
  - 複数spec並列実行機能（`--specs`オプション）
  - リアルタイム進捗表示（✅完了、🔄実行中、⏳待機中、❌失敗、⏰タイムアウト）
  - 実行結果サマリー表示

#### 変更ファイル
- `crates/cli/src/commands/mod.rs`
  - `orchestrate`モジュール追加
  - `Commands::Orchestrate`バリアント追加

- `crates/cli/src/main.rs`
  - Orchestrateコマンドのハンドリング追加
  - tokioランタイム統合

- `crates/cli/Cargo.toml`
  - `tokio = { version = "1.35", features = ["full"] }` 追加
  - `futures = "0.3"` 追加

## 受け入れ基準

- ✅ AC-6.1: `cli/src/commands/orchestrate.rs`が実装されている
- ✅ AC-6.2: `aad orchestrate --specs SPEC-001 SPEC-002`で複数Specが指定可能である
- ✅ AC-6.3: 実行ログがコンソールに表示される
- ✅ AC-6.4: 実行完了時に結果サマリーが表示される
- ✅ AC-5.1: `handle_session_completion(session_id)`メソッドが実装されている
- ✅ AC-5.2: `handle_session_failure(session_id, reason)`メソッドが実装されている
- ✅ AC-5.3: 正常完了時に次のセッションが起動される（依存関係解決済み）
- ✅ AC-5.4: 失敗時にリトライ可否が判定される

## 品質ゲート

- ✅ 全テスト成功
  - Domain: 94テスト
  - Application: 77テスト
  - Infrastructure: 32テスト
  - CLI: 2テスト
- ✅ Clippy警告なし（本番コード）
- ✅ ビルド成功

## テストコマンド

```bash
# ビルド
cargo build -p cli

# テスト実行
cargo test

# Clippy確認
cargo clippy --all-targets

# 使用例
aad orchestrate --specs SPEC-001 SPEC-002 SPEC-003
```

## 関連

- Closes #[ISSUE_NUMBER_HERE]
- SPEC-004-T06実装完了